### PR TITLE
Julia 1.0+ compatibility; add Project Toml; adapt travis for codecoverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 # Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
+codecov: true
+coveralls: true
 os:
   - linux
   - osx
+  # - windows
 julia:
   - 0.6
+  - 1.0
+  - 1.3
   - nightly
 notifications:
   email: false
@@ -13,16 +18,21 @@ git:
 
 ## uncomment the following lines to allow failures on nightly julia
 ## (tests will run but not make your overall status red)
-#matrix:
-#  allow_failures:
-#  - julia: nightly
+matrix:
+  allow_failures:
+  - julia: nightly
 
 # uncomment the following lines to override the default test script
-#script:
+script:
+  - export JL_PKG=StringLiterals
+  - julia --color=yes --inline=no -e "if VERSION < v\"0.7.0-DEV.5183\"; Pkg.clone(pwd()); Pkg.build(\"${JL_PKG}\");
+    else using Pkg; if VERSION >= v\"1.1.0-rc1\"; Pkg.build(verbose=true); else Pkg.build(); end; end"
+  - julia --check-bounds=yes --color=yes --inline=no -e "if VERSION < v\"0.7.0-DEV.5183\"; Pkg.test(\"${JL_PKG}\", coverage=true);
+    else using Pkg; Pkg.test(coverage=true); end"
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 #  - julia -e 'p="https://github.com/JuliaString"; s=".jl.git"; l="_Entities"; Pkg.clone("$p/StrTables$s"); t=("LaTeX","Emoji","HTML","Unicode"); for n in t; Pkg.clone("$p/$n$l$s"); end;  Pkg.clone("$p/Format$s"); Pkg.clone(pwd()); Pkg.add("LightXML"); Pkg.add("JSON"); for n in t; Pkg.build("$n$l"); end; Pkg.test("StringLiterals"; coverage=true)'
 after_success:
   # push coverage results to Coveralls
-  - julia -e 'cd(Pkg.dir("StringLiterals")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia -e "VERSION >= v\"0.7.0-DEV.5183\" && using Pkg; cd(Pkg.dir(\"${JL_PKG}\")); Pkg.add(\"Coverage\"); using Coverage; Coveralls.submit(Coveralls.process_folder())"
   # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("StringLiterals")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e "VERSION >= v\"0.7.0-DEV.5183\" && using Pkg; cd(Pkg.dir(\"${JL_PKG}\")); Pkg.add(\"Coverage\"); using Coverage; Codecov.submit(Codecov.process_folder())"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,17 @@
+name = "StringLiterals"
+uuid = "a2a04ff6-0b4b-5b5a-81f5-329e130e9e99"
+version = "1.0.0-DEV"
+
+[deps]
+Emoji_Entities = "fd8f23de-bd2f-5c75-921c-0c9ab51355f5"
+Format = "1fa38f19-a742-5d3f-a2b9-30dd87b9d5f8"
+HTML_Entities = "7693890a-d069-55fe-a829-b4a6d304f0ee"
+LaTeX_Entities = "9927f19a-46ce-5bdd-a20a-f46a78b61e3d"
+StrTables = "9700d1a9-a7c8-5760-9816-a99fda30bb8f"
+Unicode_Entities = "a8aa15d3-c567-5e9f-b6cc-4b0f97f09cf7"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/src/StringLiterals.jl
+++ b/src/StringLiterals.jl
@@ -34,6 +34,12 @@ else
     outhex(c, p=1) = string(UInt32(c), base=16, pad=p)
 end
 
+@static if VERSION >= v"1.0.0"
+    const next = iterate
+    start(iter) = 1
+    done(iter, state) = iterate(iter, state) === nothing
+end
+
 """
 String macro with more Swift-like syntax, plus support for emojis and LaTeX names
 """


### PR DESCRIPTION
Some people, including myself, are missing the functionality of `StringLiterals` in the latest Julia version. So I thought, why not making this nice package 1.0 compatible.

The changes are
- added the compatibility functions `start()`, `next()` and `done()` for iterables which were removed from Julia 1.0 on
- created a `Project.toml` and give the packge the version number `1.0.0-DEV`
- adapted Travis to test with the inline=no option in order to get around the [missing lines](https://github.com/JuliaLang/julia/issues/28192) issue in Coverage.jl.

This version runs on all OSes with Julia versions from 0.6 to nightly.
I hope, this could be a version to be again registered with the Julia repositories.
